### PR TITLE
Convert numeric socket messages to numbers before sending to OSC

### DIFF
--- a/bridge.js
+++ b/bridge.js
@@ -18,6 +18,11 @@ io.on('connection', function (socket) {
   });
   socket.on('message', function (obj) {
     var toSend = obj.split(' ');
+
+    toSend = toSend.map(function (el) {
+      return isNaN(el) ? el : parseFloat(el);
+    });
+
     oscClient.send(...toSend);
     console.log('sent WS message to OSC', toSend);
   });


### PR DESCRIPTION
#### Problem
When numeric values are sent to the socket, they are parsed as strings and subsequently sent out via OSC as strings too (e.g., `"5"` instead of `5`). This causes issues with programs like Wekinator that expect properly formatted numeric data.

#### Solution
This fix traverses the list of values and converts any numeric strings to floats before sending them via OSC. Fixes #26 

#### Impact
This fundamentally changes how the program sends data. If merged, I recommend updating the version number to **0.2.2** to reflect this change.